### PR TITLE
Piccolo errore

### DIFF
--- a/Italian/main/Contacts.apk/res/values-it/strings.xml
+++ b/Italian/main/Contacts.apk/res/values-it/strings.xml
@@ -814,7 +814,7 @@ Le schede contatti sono disattivate"</string>
     <string name="callrecordview_menu_conference">Audio conferenza</string>
     <string name="openDialKeyboard">Tastierino</string>
     <string name="t9_search_guide_pinyin_title1">Trova rapidamente i contatti inserendo alcune lettere</string>
-    <string name="t9_search_guide_pinyin_title2">Inserisci 9 e 9 per cercare Xiaomi Hugo</string>
+    <string name="t9_search_guide_pinyin_title2">Inserisci 9 e 4 per cercare Xiaomi Hugo</string>
     <string name="t9_search_guide_zhuyin_title1">Trova rapidamente i contatti inserendo alcune lettere</string>
     <string name="t9_search_guide_zhuyin_title2">Inserisci 5 e 6 per cercare Jeff Max</string>
     <string name="date_time_set">Imposta</string>


### PR DESCRIPTION
Il numero giusto per la lettera "H" è il 4 non il 9